### PR TITLE
feat: convert utils/cookies to TS && feat(meta): allow build for both TS and JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,14 @@
   "main": "lib/index.js",
   "sideEffects": false,
   "scripts": {
-    "build": "babel src -d lib --ignore **/*.test.js",
-    "build:watch": "babel src -d lib --ignore **/*.test.js --watch",
+    "babel": "yarn babel:js && yarn babel:ts",
+    "babel:js": "babel src -d lib --ignore '**/*.test.js','**/__fixtures__'",
+    "babel:ts": "yarn babel:js --ignore '**/*.test.ts' --extensions '.ts'",
+    "types": "yarn types:flow && yarn types:ts",
+    "types:flow": "find src -name '*.js.flow' -exec sh -c 'cp \"$0\" \"${0/src/lib}\"' '{}' \\;",
+    "types:ts": "tsc --project tsconfig.types.json",
+    "prebuild": "rimraf lib",
+    "build": "yarn babel && yarn types",
     "test": "ALL_TESTS=true jest",
     "lint": "eslint --ext js,js.flow,ts src --quiet",
     "lint:fix": "yarn lint --fix",
@@ -14,7 +20,7 @@
     "flow": "flow",
     "flow:start": "flow start",
     "flow:stop": "flow stop",
-    "localsync": "rimraf lib && yarn build && yalc push"
+    "localsync": "yarn build && yalc push"
   },
   "repository": "git+https://github.com/kiwicom/splitster.git",
   "author": "Vladimír Jarabica",
@@ -25,7 +31,6 @@
   "homepage": "https://github.com/kiwicom/splitster#readme",
   "files": [
     "lib/**",
-    "src/**/*.js.flow",
     ".flowconfig"
   ],
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,0 @@
-export { default as init } from "./clients/index";
-
-export { parseCookies } from "./utils/cookies";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
+// @ts-expect-error This is a JS file that hasn't been converted yet
+export { default as init } from "./clients";
+
+export { parseCookies } from "./utils/cookies";
+
 export type DisabledReason =
   | "usage"
   | "separate_test"

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,3 +81,7 @@ export type UserGroup<U extends User = User> = UserGroupRule<U> | UserGroupRule<
 export type SplitsterInitConfig<U extends User = User, V extends Variants = Variants> = {
   tests: Tests<U, V>;
 };
+
+// SplitsterClient
+
+export type SplitsterResults = Record<string, string>;

--- a/src/utils/cookies.test.ts
+++ b/src/utils/cookies.test.ts
@@ -8,7 +8,7 @@ const RANDOM_COOKIES = {
 };
 
 describe("filterCookiesByPrefix", () => {
-  it("should return cookies specific to Splitster", () => {
+  test("should return cookies specific to Splitster", () => {
     const SPLITSTER_COOKIES = {
       "splitster_test_show_widget=show": "value",
       "splitster_test_button_color=red": "value2",
@@ -18,10 +18,10 @@ describe("filterCookiesByPrefix", () => {
       ...SPLITSTER_COOKIES,
       ...RANDOM_COOKIES,
     };
-    expect(filterCookiesByPrefix(COOKIES)).toEqual(SPLITSTER_COOKIES_KEYS);
+    expect(filterCookiesByPrefix(COOKIES)).toStrictEqual(SPLITSTER_COOKIES_KEYS);
   });
 
-  it("should return cookies specific to Splitster -- CUSTOM PREFIX", () => {
+  test("should return cookies specific to Splitster -- CUSTOM PREFIX", () => {
     const prefix = "my great prefix";
     const SPLITSTER_COOKIES_WITH_CUSTOM_PREFIX = {
       [`${prefix}test_show_widget=show`]: "value",
@@ -34,14 +34,14 @@ describe("filterCookiesByPrefix", () => {
       ...SPLITSTER_COOKIES_WITH_CUSTOM_PREFIX,
       ...RANDOM_COOKIES,
     };
-    expect(filterCookiesByPrefix(COOKIES, prefix)).toEqual(
+    expect(filterCookiesByPrefix(COOKIES, prefix)).toStrictEqual(
       SPLITSTER_COOKIES_WITH_CUSTOM_PREFIX_KEYS,
     );
   });
 });
 
 describe("parseCookies", () => {
-  it("returns Splitster specific cookies with the prefix removed from the cookie key", () => {
+  test("returns Splitster specific cookies with the prefix removed from the cookie key", () => {
     const SPLITSTER_COOKIES = {
       "splitster_test_show_widget=show": "value",
       "splitster_test_button_color=red": "value2",
@@ -54,10 +54,10 @@ describe("parseCookies", () => {
       ...SPLITSTER_COOKIES,
       ...RANDOM_COOKIES,
     };
-    expect(parseCookies(COOKIES)).toEqual(SPLITSTER_COOKIES_WITHOUT_PREFIX);
+    expect(parseCookies(COOKIES)).toStrictEqual(SPLITSTER_COOKIES_WITHOUT_PREFIX);
   });
 
-  it("parses Splitster specific cookies with the prefix removed from the cookie key -- CUSTOM PREFIX", () => {
+  test("parses Splitster specific cookies with the prefix removed from the cookie key -- CUSTOM PREFIX", () => {
     const prefix = "my great prefix";
     const SPLITSTER_COOKIES_WITH_CUSTOM_PREFIX = {
       [`${prefix}test_show_widget=show`]: "value",
@@ -71,6 +71,6 @@ describe("parseCookies", () => {
       ...SPLITSTER_COOKIES_WITH_CUSTOM_PREFIX,
       ...RANDOM_COOKIES,
     };
-    expect(parseCookies(COOKIES, prefix)).toEqual(SPLITSTER_COOKIES_WITHOUT_PREFIX);
+    expect(parseCookies(COOKIES, prefix)).toStrictEqual(SPLITSTER_COOKIES_WITHOUT_PREFIX);
   });
 });

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,5 +1,7 @@
 import R from "ramda";
 
+import type { SplitsterResults } from "..";
+
 /**
  * How cookies will be set
  *
@@ -12,16 +14,13 @@ import R from "ramda";
  * tracks will be in config
  * ... so basically tests are enough for now
  */
-export const filterCookiesByPrefix = (cookies, prefix = "splitster_") =>
+export const filterCookiesByPrefix = (cookies: SplitsterResults, prefix = "splitster_") =>
   R.filter(R.startsWith(prefix), R.keys(cookies));
 
 /**
  * Parse cookies with keys {prefix_test_id} to {test_id}
- * @param prefix
- * @param cookies
- * @returns {*}
  */
-export const parseCookies = (cookies, prefix = "splitster_") =>
+export const parseCookies = (cookies: SplitsterResults, prefix = "splitster_") =>
   R.reduce(
     (acc, key) => R.assoc(R.slice(prefix.length, key.length, key), cookies[key], acc),
     {},

--- a/src/utils/cookies.ts
+++ b/src/utils/cookies.ts
@@ -1,4 +1,4 @@
-import R from "ramda";
+import * as R from "ramda";
 
 import type { SplitsterResults } from "..";
 
@@ -20,7 +20,7 @@ export const filterCookiesByPrefix = (cookies: SplitsterResults, prefix = "split
 /**
  * Parse cookies with keys {prefix_test_id} to {test_id}
  */
-export const parseCookies = (cookies: SplitsterResults, prefix = "splitster_") =>
+export const parseCookies = (cookies: SplitsterResults, prefix = "splitster_"): SplitsterResults =>
   R.reduce(
     (acc, key) => R.assoc(R.slice(prefix.length, key.length, key), cookies[key], acc),
     {},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,8 @@
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "outDir": "./lib",                        /* Redirect output structure to the directory. */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.ts", "**/__fixtures__"],
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true
+  }
+}


### PR DESCRIPTION
### **feat: convert utils/cookies to TS**

--- 

### **feat(meta): allow build for both TS and JS**

We use Babel to transpile the TS files to ensure we can
leverage the plugins (like for Ramda) and have the same
JavaScript target for both JS and TS files.
Because we copy the Flow files next to the JS built files
in lib, we don't need to include them from the `src`
directory.


---

Resulting `lib` folder:
<img width="205" alt="Screenshot 2020-11-19 at 16 47 30" src="https://user-images.githubusercontent.com/22741774/99689992-e96b3180-2a87-11eb-9ce7-8779c299c099.png">
